### PR TITLE
fix(style): use 100% and svh units for better viewport handling

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -70,8 +70,8 @@ body {
     "Segoe UI", Meiryo, Tahoma, Arial, sans-serif;
   margin: 0;
   padding: 0;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100svh;
   display: flex;
 }
 


### PR DESCRIPTION
Chrome(Desktop)環境で横スクロールが発生していて気持ち悪かったので、修正しました。
Firefoxでレイアウトの悪影響ないかはチェック済みです。
- 100vw → 100%: Scrollバー領域が発生するとその分はみ出るので修正
- 100vh → 100svh: vhだとSPブラウザのアドレスバー等が含まれるので修正
### Before:
<img width="1069" height="910" alt="image" src="https://github.com/user-attachments/assets/85b2ba71-fcd2-4381-9bf7-e71356c8d2c4" />

### After:
<img width="1065" height="904" alt="image" src="https://github.com/user-attachments/assets/d92582c0-a941-407c-a773-b1a64eb228e8" />

